### PR TITLE
Prevent folder name from ending in ".git"

### DIFF
--- a/src/net/avicus/scaffold/ScaffoldCmd.java
+++ b/src/net/avicus/scaffold/ScaffoldCmd.java
@@ -68,7 +68,10 @@ public class ScaffoldCmd implements CommandExecutor {
             }
 
             String url = args[1];
-            String name = url.split("/")[url.split("/").length - 1];
+            String name = url.split("/")[url.split("/").length - 1
+            
+            if (name.endsWith(".git"))
+                name = name.substring(0, name.length - 4);
 
             if (args.length > 2)
                 name = args[2];


### PR DESCRIPTION
This PR prevents the output folder name from ending in ```.git```, I find it annoying have world's where their names end in ```.git```.

**NOTE:** This will not override the name if the user has specified the name!